### PR TITLE
Use new 1.1 rules greaterOrEqual and lessOrEqual

### DIFF
--- a/Scenarios/ALKS_Scenario_4.1_1_FreeDriving_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.1_1_FreeDriving_TEMPLATE.xosc
@@ -74,7 +74,7 @@
                 <ConditionGroup>
                   <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -84,9 +84,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -97,7 +97,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>

--- a/Scenarios/ALKS_Scenario_4.1_2_SwervingLeadVehicle_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.1_2_SwervingLeadVehicle_TEMPLATE.xosc
@@ -100,9 +100,9 @@
               </Action>
               <StartTrigger>
                 <ConditionGroup>
-                  <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
+                  <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="none">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -112,9 +112,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -145,7 +145,7 @@
                 <ConditionGroup>
                   <Condition name="SwerveEventStart" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="5.0" rule="greaterThan" />
+                      <SimulationTimeCondition value="5.0" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -224,9 +224,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="SwerveActStart" delay="0" conditionEdge="rising">
+            <Condition name="SwerveActStart" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0.0" rule="greaterThan" />
+                <SimulationTimeCondition value="0.0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -237,7 +237,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>

--- a/Scenarios/ALKS_Scenario_4.1_3_SwervingSideVehicle_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.1_3_SwervingSideVehicle_TEMPLATE.xosc
@@ -102,7 +102,7 @@
                 <ConditionGroup>
                   <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -112,9 +112,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -145,7 +145,7 @@
                 <ConditionGroup>
                   <Condition name="SwerveEventStart" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="5.0" rule="greaterThan" />
+                      <SimulationTimeCondition value="5.0" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -224,9 +224,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="SwerveActStart" delay="0" conditionEdge="rising">
+            <Condition name="SwerveActStart" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0.0" rule="greaterThan" />
+                <SimulationTimeCondition value="0.0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -237,7 +237,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>

--- a/Scenarios/ALKS_Scenario_4.2_1_FullyBlockingTarget_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.2_1_FullyBlockingTarget_TEMPLATE.xosc
@@ -89,7 +89,7 @@
                 <ConditionGroup>
                   <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -99,9 +99,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -112,7 +112,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>

--- a/Scenarios/ALKS_Scenario_4.2_2_PartiallyBlockingTarget_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.2_2_PartiallyBlockingTarget_TEMPLATE.xosc
@@ -90,7 +90,7 @@
                 <ConditionGroup>
                   <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -100,9 +100,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -113,7 +113,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>

--- a/Scenarios/ALKS_Scenario_4.2_3_CrossingPedestrian_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.2_3_CrossingPedestrian_TEMPLATE.xosc
@@ -90,7 +90,7 @@
                 <ConditionGroup>
                   <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -100,9 +100,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -170,9 +170,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="CrossActStart" delay="0" conditionEdge="rising">
+            <Condition name="CrossActStart" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -183,7 +183,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>

--- a/Scenarios/ALKS_Scenario_4.2_4_MultipleBlockingTargets_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.2_4_MultipleBlockingTargets_TEMPLATE.xosc
@@ -102,7 +102,7 @@
                 <ConditionGroup>
                   <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -112,9 +112,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -125,7 +125,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>

--- a/Scenarios/ALKS_Scenario_4.3_1_FollowLeadVehicleComfortable_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.3_1_FollowLeadVehicleComfortable_TEMPLATE.xosc
@@ -102,7 +102,7 @@
                 <ConditionGroup>
                   <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -112,9 +112,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -145,7 +145,7 @@
                 <ConditionGroup>
                   <Condition name="VaryingSpeedStartCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10.0" rule="greaterThan" />
+                      <SimulationTimeCondition value="10.0" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -178,9 +178,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="VaryingSpeedActStart" delay="0" conditionEdge="rising">
+            <Condition name="VaryingSpeedActStart" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0.0" rule="greaterThan" />
+                <SimulationTimeCondition value="0.0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -191,7 +191,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>

--- a/Scenarios/ALKS_Scenario_4.3_2_FollowLeadVehicleEmergencyBrake_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.3_2_FollowLeadVehicleEmergencyBrake_TEMPLATE.xosc
@@ -100,7 +100,7 @@
                 <ConditionGroup>
                   <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -110,9 +110,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -143,7 +143,7 @@
                 <ConditionGroup>
                   <Condition name="BrakeStartCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10.0" rule="greaterThan" />
+                      <SimulationTimeCondition value="10.0" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -153,9 +153,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="BrakeActStart" delay="0" conditionEdge="rising">
+            <Condition name="BrakeActStart" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0.0" rule="greaterThan" />
+                <SimulationTimeCondition value="0.0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -166,7 +166,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>

--- a/Scenarios/ALKS_Scenario_4.4_1_CutInNoCollision_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.4_1_CutInNoCollision_TEMPLATE.xosc
@@ -103,7 +103,7 @@
                 <ConditionGroup>
                   <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -113,9 +113,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -173,9 +173,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="CutInActStart" delay="0" conditionEdge="rising">
+            <Condition name="CutInActStart" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -186,7 +186,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>

--- a/Scenarios/ALKS_Scenario_4.4_2_CutInUnavoidableCollision_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.4_2_CutInUnavoidableCollision_TEMPLATE.xosc
@@ -103,7 +103,7 @@
                 <ConditionGroup>
                   <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -113,9 +113,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -173,9 +173,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="CutInActStart" delay="0" conditionEdge="rising">
+            <Condition name="CutInActStart" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -186,7 +186,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>

--- a/Scenarios/ALKS_Scenario_4.5_1_CutOutFullyBlocking_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.5_1_CutOutFullyBlocking_TEMPLATE.xosc
@@ -116,7 +116,7 @@
                 <ConditionGroup>
                   <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -126,9 +126,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -174,9 +174,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="CutOutActStart" delay="0" conditionEdge="rising">
+            <Condition name="CutOutActStart" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -187,7 +187,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>

--- a/Scenarios/ALKS_Scenario_4.5_2_CutOutMultipleBlockingTargets_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.5_2_CutOutMultipleBlockingTargets_TEMPLATE.xosc
@@ -127,7 +127,7 @@
                 <ConditionGroup>
                   <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -137,9 +137,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -185,9 +185,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="CutOutActStart" delay="0" conditionEdge="rising">
+            <Condition name="CutOutActStart" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -198,7 +198,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>

--- a/Scenarios/ALKS_Scenario_4.6_1_ForwardDetectionRange_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.6_1_ForwardDetectionRange_TEMPLATE.xosc
@@ -90,7 +90,7 @@
                 <ConditionGroup>
                   <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -100,9 +100,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -113,7 +113,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>

--- a/Scenarios/ALKS_Scenario_4.6_2_LateralDetectionRange_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.6_2_LateralDetectionRange_TEMPLATE.xosc
@@ -102,7 +102,7 @@
                 <ConditionGroup>
                   <Condition name="ActivateALKSControllerEventCondition" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="10000" rule="greaterThan" />
+                      <SimulationTimeCondition value="10000" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -112,9 +112,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="rising">
+            <Condition name="ActivateALKSControllerActCondition" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0" rule="greaterThan" />
+                <SimulationTimeCondition value="0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -145,7 +145,7 @@
                 <ConditionGroup>
                   <Condition name="SwerveEventStart" delay="0" conditionEdge="rising">
                     <ByValueCondition>
-                      <SimulationTimeCondition value="5.0" rule="greaterThan" />
+                      <SimulationTimeCondition value="5.0" rule="greaterOrEqual" />
                     </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
@@ -224,9 +224,9 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="SwerveActStart" delay="0" conditionEdge="rising">
+            <Condition name="SwerveActStart" delay="0" conditionEdge="none">
               <ByValueCondition>
-                <SimulationTimeCondition value="0.0" rule="greaterThan" />
+                <SimulationTimeCondition value="0.0" rule="greaterOrEqual" />
               </ByValueCondition>
             </Condition>
           </ConditionGroup>
@@ -237,7 +237,7 @@
       <ConditionGroup>
         <Condition name="End" delay="0" conditionEdge="rising">
           <ByValueCondition>
-            <SimulationTimeCondition value="$Duration" rule="greaterThan" />
+            <SimulationTimeCondition value="$Duration" rule="greaterOrEqual" />
           </ByValueCondition>
         </Condition>
       </ConditionGroup>


### PR DESCRIPTION
- results in more accurate scenario execution
- acts are started in first step
- cut-in, cut-out and crossing pedestrian can also be triggered on exact
  distance / headway time (no impact because of double comparison)

Tested successfully with esmini 2.11.2.

Signed-off-by: Andreas Rauschert <andreas.rb.rauschert@bmw.de>

Closes: https://github.com/asam-oss/OSC-ALKS-scenarios/issues/43