### PR TITLE
Remove variation of CutInVehicle_Model when not declared in base scenario

### DIFF
--- a/Variations/ALKS_Scenario_4.5_1_CutOutFullyBlocking_Variation.xosc
+++ b/Variations/ALKS_Scenario_4.5_1_CutOutFullyBlocking_Variation.xosc
@@ -30,15 +30,6 @@
           <Range lowerLimit="0.5" upperLimit="3.0" />
         </DistributionRange>
       </DeterministicSingleParameterDistribution>
-      <DeterministicSingleParameterDistribution parameterName="CutInVehicle_Model">
-        <DistributionSet>
-          <Element value="car" />
-          <Element value="truck" />
-          <Element value="van" />
-          <Element value="bus" />
-          <Element value="motorbike" />
-        </DistributionSet>
-      </DeterministicSingleParameterDistribution>
       <DeterministicMultiParameterDistribution>
         <ValueSetDistribution>
           <ParameterValueSet>

--- a/Variations/ALKS_Scenario_4.5_2_CutOutMultipleBlockingTargets_Variation.xosc
+++ b/Variations/ALKS_Scenario_4.5_2_CutOutMultipleBlockingTargets_Variation.xosc
@@ -30,15 +30,6 @@
           <Range lowerLimit="0.5" upperLimit="3.0" />
         </DistributionRange>
       </DeterministicSingleParameterDistribution>
-      <DeterministicSingleParameterDistribution parameterName="CutInVehicle_Model">
-        <DistributionSet>
-          <Element value="car" />
-          <Element value="truck" />
-          <Element value="van" />
-          <Element value="bus" />
-          <Element value="motorbike" />
-        </DistributionSet>
-      </DeterministicSingleParameterDistribution>
       <DeterministicMultiParameterDistribution>
         <ValueSetDistribution>
           <ParameterValueSet>


### PR DESCRIPTION
- remove parameter from CutOutFullyBlocking and CutOutMultipleBlockingTargets for variation as it is not part of the template scenario