### PR TITLE
Fix: parameter type of relative lane id

### DIFF
--- a/Scenarios/ALKS_Scenario_4.1_3_SideVehicle_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.1_3_SideVehicle_TEMPLATE.xosc
@@ -23,7 +23,7 @@
       </ConstraintGroup>
       <!--With a longitudinal offset of more than 10.0 m the vehicle isn't considered to be close beside anymore as required by the regulation.-->
     </ParameterDeclaration>
-    <ParameterDeclaration name="SideVehicle_InitPosition_RelativeLaneId" parameterType="int" value="1">
+    <ParameterDeclaration name="SideVehicle_InitPosition_RelativeLaneId" parameterType="integer" value="1">
       <!--Left=1, Right=-1-->
       <ConstraintGroup>
         <ValueConstraint rule="equalTo" value="1"></ValueConstraint>

--- a/Scenarios/ALKS_Scenario_4.1_3_SideVehicle_TEMPLATE.xosc
+++ b/Scenarios/ALKS_Scenario_4.1_3_SideVehicle_TEMPLATE.xosc
@@ -23,7 +23,7 @@
       </ConstraintGroup>
       <!--With a longitudinal offset of more than 10.0 m the vehicle isn't considered to be close beside anymore as required by the regulation.-->
     </ParameterDeclaration>
-    <ParameterDeclaration name="SideVehicle_InitPosition_RelativeLaneId" parameterType="string" value="1">
+    <ParameterDeclaration name="SideVehicle_InitPosition_RelativeLaneId" parameterType="int" value="1">
       <!--Left=1, Right=-1-->
       <ConstraintGroup>
         <ValueConstraint rule="equalTo" value="1"></ValueConstraint>


### PR DESCRIPTION
Type of SideVehicle_InitPosition_RelativeLaneId must be "integer" since it is used in a RelativeLanePosition, where the dLane attribute is of type "integer". Also it is used in an expression where an integer type is expected.